### PR TITLE
fix(handler) proxy-cache does not cache ngx.resp

### DIFF
--- a/kong-proxy-cache-plugin-1.2.1-0.rockspec
+++ b/kong-proxy-cache-plugin-1.2.1-0.rockspec
@@ -1,9 +1,9 @@
 package = "kong-proxy-cache-plugin"
-version = "1.2.0-0"
+version = "1.2.1-0"
 
 source = {
   url = "git://github.com/Kong/kong-plugin-proxy-cache",
-  tag = "1.2.0"
+  tag = "1.2.1"
 }
 
 supported_platforms = {"linux", "macosx"}

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -9,6 +9,7 @@ local floor            = math.floor
 local get_method       = ngx.req.get_method
 local ngx_get_uri_args = ngx.req.get_uri_args
 local ngx_get_headers  = ngx.req.get_headers
+local resp_get_headers = ngx.resp and ngx.resp.get_headers
 local ngx_log          = ngx.log
 local ngx_now          = ngx.now
 local ngx_re_gmatch    = ngx.re.gmatch
@@ -413,7 +414,7 @@ function ProxyCacheHandler:header_filter(conf)
 
   -- if this is a cacheable request, gather the headers and mark it so
   if cacheable_response(ngx, conf, cc) then
-    ctx.res_headers = ngx.resp.get_headers(0, true)
+    ctx.res_headers = resp_get_headers(0, true)
     ctx.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
     ngx.ctx.proxy_cache = ctx
 

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -9,7 +9,6 @@ local floor            = math.floor
 local get_method       = ngx.req.get_method
 local ngx_get_uri_args = ngx.req.get_uri_args
 local ngx_get_headers  = ngx.req.get_headers
-local resp_get_headers = ngx.resp.get_headers
 local ngx_log          = ngx.log
 local ngx_now          = ngx.now
 local ngx_re_gmatch    = ngx.re.gmatch
@@ -253,7 +252,7 @@ local ProxyCacheHandler = BasePlugin:extend()
 
 
 ProxyCacheHandler.PRIORITY = 100
-ProxyCacheHandler.VERSION = "1.2.0"
+ProxyCacheHandler.VERSION = "1.2.1"
 
 
 function ProxyCacheHandler:new()
@@ -414,7 +413,7 @@ function ProxyCacheHandler:header_filter(conf)
 
   -- if this is a cacheable request, gather the headers and mark it so
   if cacheable_response(ngx, conf, cc) then
-    ctx.res_headers = resp_get_headers(0, true)
+    ctx.res_headers = ngx.resp.get_headers(0, true)
     ctx.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
     ngx.ctx.proxy_cache = ctx
 


### PR DESCRIPTION
- proxy-cache plugin was trying to cache ngx.resp.get_headers() locally in handler.lua, but this function is not available in init phase.
- Version bump.