### PR TITLE
chore(ci) de duplicate the dependency pinning logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,17 @@ install:
   - pushd kong-source && make dev && popd
   - cp -r kong-source/spec/fixtures spec
 
+stages:
+  - lint
+  - test
+
+jobs:
+  include:
+    - stage: lint
+      env:
+        - TEST_SUITE=lint
+      script: luacheck kong/
+
 script:
   - pushd kong-source && bin/busted $BUSTED_ARGS ../spec && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,6 @@ env:
     - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2.12 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
     - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
     - KONG_TEST_DATABASE=postgres POSTGRES=9.5 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,cassandra,off"
-matrix:
-  allow_failures:
-    - env: KONG_TEST_DATABASE=postgres POSTGRES=9.5 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,cassandra,off"
 
 install:
   - make setup-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,17 +46,6 @@ install:
   - pushd kong-source && make dev && popd
   - cp -r kong-source/spec/fixtures spec
 
-stages:
-  - lint
-  - test
-
-jobs:
-  include:
-    - stage: lint
-      env:
-        - TEST_SUITE=lint
-      script: luacheck .
-
 script:
   - pushd kong-source && bin/busted $BUSTED_ARGS ../spec && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ services:
 
 env:
   global:
+    - TEST_SUITE=integration
     - INSTALL_CACHE=$HOME/install-cache
     - DOWNLOAD_ROOT=$HOME/download-root
     - PLUGIN_NAME=proxy-cache
@@ -44,7 +45,7 @@ install:
   - cp -r kong-source/spec/fixtures spec
 
 script:
-  - pushd kong-source && bin/busted $BUSTED_ARGS spec && popd
+  - pushd kong-source && bin/busted $BUSTED_ARGS ../spec && popd
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,17 @@ install:
   - pushd kong-source && make dev && popd
   - cp -r kong-source/spec/fixtures spec
 
+stages:
+  - lint
+  - test
+
+jobs:
+  include:
+    - stage: lint
+      env:
+        - TEST_SUITE=lint
+      script: luacheck .
+
 script:
   - pushd kong-source && bin/busted $BUSTED_ARGS ../spec && popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
-dist: trusty
-sudo: required
+dist: xenial
+sudo: false
 
-language: java
+language: generic
 
 jdk:
   - oraclejdk8
@@ -16,51 +16,38 @@ addons:
       - net-tools
       - libpcre3-dev
       - build-essential
+  hosts:
+    - grpcs_1.test
+    - grpcs_2.test
 
 services:
   - docker
 
 env:
   global:
-    - LUAROCKS=3.0.4
-    - OPENSSL=1.1.1a
-    - CASSANDRA_BASE=2.2.12
-    - CASSANDRA_LATEST=3.9
-    - OPENRESTY_LATEST=1.13.6.2
-    - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
-    - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
+    - DOWNLOAD_ROOT=$HOME/download-root
     - PLUGIN_NAME=proxy-cache
     - KONG_PLUGINS=bundled,$PLUGIN_NAME
     - KONG_TEST_PLUGINS=$KONG_PLUGINS
     - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
-
+    - JOBS=2
   matrix:
-    - OPENRESTY=$OPENRESTY_LATEST
-      CASSANDRA=$CASSANDRA_BASE
-    - OPENRESTY=$OPENRESTY_LATEST
-      CASSANDRA=$CASSANDRA_LATEST
-
-before_install:
-  - git clone https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git
-  - source kong-ci/setup_env.sh
-  - git clone https://github.com/Kong/kong.git kong-ce
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2.12 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
+    - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
+    - KONG_TEST_DATABASE=postgres POSTGRES=9.5 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,cassandra,off"
 
 install:
-  - luarocks make
-  - cd kong-ce
-  - git checkout next
-  - make dev
-  - cp -r spec/fixtures ../spec
-  - createuser --createdb kong
-  - createdb -U kong kong_tests
+  - make setup-ci
+  - pushd kong-source && source .ci/setup_env.sh && popd
+  - pushd kong-source && make dev && popd
+  - cp -r kong-source/spec/fixtures spec
 
 script:
-  - bin/busted $BUSTED_ARGS ../spec
+  - pushd kong-source && bin/busted $BUSTED_ARGS spec && popd
 
 cache:
   apt: true
-  pip: true
   directories:
     - $DOWNLOAD_CACHE
     - $INSTALL_CACHE

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ env:
     - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2.12 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
     - KONG_TEST_DATABASE=cassandra CASSANDRA=3.9 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"
     - KONG_TEST_DATABASE=postgres POSTGRES=9.5 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,cassandra,off"
+matrix:
+  allow_failures:
+    - env: KONG_TEST_DATABASE=postgres POSTGRES=9.5 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,cassandra,off"
 
 install:
   - make setup-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ env:
     - KONG_PLUGINS=bundled,$PLUGIN_NAME
     - KONG_TEST_PLUGINS=$KONG_PLUGINS
     - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
+    - KONG_TEST_PG_DATABASE=travis
+    - KONG_TEST_PG_USER=postgres
     - JOBS=2
   matrix:
     - KONG_TEST_DATABASE=cassandra CASSANDRA=2.2.12 KONG=master BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6,postgres,off"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+KONG_SOURCE_LOCATION?=$(ROOT_DIR)/kong-source
+KONG?=master
+
+setup-kong:
+	-rm -rf $(KONG_SOURCE_LOCATION); \
+	git clone --branch $(KONG) https://github.com/Kong/kong.git $(KONG_SOURCE_LOCATION)
+
+setup-ci: setup-kong
+	cd $(KONG_SOURCE_LOCATION); \
+	$(MAKE) setup-ci


### PR DESCRIPTION
Utilize the Kong make / bash to de duplicate the dependency pinning logic. Instead of this repository setting the openresty / luarocks / openssl versions we should be using rely on Kong `make setup-ci` to utilize the dependencies as defined in it's `.requirements` file