### PR TITLE
fix(api) avoid HTTP 500 in /proxy-cache when multiple plugins are active

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,8 @@ services:
 
 env:
   global:
-    - LUAROCKS=3.0.4
-    - OPENSSL=1.1.1a
     - CASSANDRA_BASE=2.2.12
     - CASSANDRA_LATEST=3.9
-    - OPENRESTY_LATEST=1.13.6.2
     - DOWNLOAD_CACHE=$HOME/download-cache
     - INSTALL_CACHE=$HOME/install-cache
     - BUSTED_ARGS="-o gtest -v --exclude-tags=flaky,ipv6"
@@ -36,20 +33,24 @@ env:
     - TEST_FILE_PATH=$TRAVIS_BUILD_DIR/spec
 
   matrix:
-    - OPENRESTY=$OPENRESTY_LATEST
-      CASSANDRA=$CASSANDRA_BASE
-    - OPENRESTY=$OPENRESTY_LATEST
-      CASSANDRA=$CASSANDRA_LATEST
+    - CASSANDRA=$CASSANDRA_BASE
+      KONG_BRANCH=master
+    - CASSANDRA=$CASSANDRA_LATEST
+      KONG_BRANCH=next
+    - CASSANDRA=$CASSANDRA_BASE
+      KONG_BRANCH=master
+    - CASSANDRA=$CASSANDRA_LATEST
+      KONG_BRANCH=next
 
 before_install:
   - git clone https://$GITHUB_TOKEN:@github.com/Kong/kong-ci.git
-  - source kong-ci/setup_env.sh
   - git clone https://github.com/Kong/kong.git kong-ce
+  - ( cd kong-ce; git checkout $KONG_BRANCH )
+  - source kong-ce/.requirements && OPENRESTY=$RESTY_VERSION LUAROCKS=$RESTY_LUAROCKS_VERSION OPENSSL=$RESTY_OPENSSL_VERSION PCRE=$RESTY_PCRE_VERSION source kong-ci/setup_env.sh
 
 install:
   - luarocks make
   - cd kong-ce
-  - git checkout next
   - make dev
   - cp -r spec/fixtures ../spec
   - createuser --createdb kong

--- a/spec/03-api_spec.lua
+++ b/spec/03-api_spec.lua
@@ -24,6 +24,13 @@ describe("Plugin: proxy-cache", function()
       },
     })
 
+    -- an additional plugin does not interfere with the iteration in
+    -- the global /proxy-cache API handler: regression test for
+    -- https://github.com/Kong/kong-plugin-proxy-cache/issues/12
+    assert(bp.plugins:insert {
+      name = "request-transformer",
+    })
+
     local route2 = assert(bp.routes:insert {
       hosts = { "route-2.com" },
     })
@@ -41,7 +48,7 @@ describe("Plugin: proxy-cache", function()
     })
 
     assert(helpers.start_kong({
-      plugins = "proxy-cache",
+      plugins = "proxy-cache,request-transformer",
       nginx_conf = "spec/fixtures/custom_nginx.template",
     }))
 


### PR DESCRIPTION
Avoid a HTTP 500 error triggered in the global `/proxy-cache` endpoint
when other plugins are also active. This fixes the iteration logic
to ensure it goes only through the proxy-cache plugins.

Fixes #12