### PR TITLE
refactor(*) use pdk, remove apis and style changes

### DIFF
--- a/kong/plugins/proxy-cache/api.lua
+++ b/kong/plugins/proxy-cache/api.lua
@@ -1,14 +1,15 @@
 local STRATEGY_PATH = "kong.plugins.proxy-cache.strategies"
 
 
+local require = require
 local kong = kong
-local cluster_events = kong.cluster_events
+local fmt = string.format
 
 
 local function broadcast_purge(plugin_id, cache_key)
-  local data = string.format("%s:%s", plugin_id, cache_key or "nil")
-  ngx.log(ngx.DEBUG, "[proxy-cache] broadcasting purge '", data, "'")
-  return cluster_events:broadcast("proxy-cache:purge", data)
+  local data = fmt("%s:%s", plugin_id, cache_key or "nil")
+  kong.log.debug("broadcasting purge '", data, "'")
+  return kong.cluster_events:broadcast("proxy-cache:purge", data)
 end
 
 
@@ -53,8 +54,7 @@ return {
         then
           local ok, err = broadcast_purge(plugin.id, nil)
           if not ok then
-            ngx.log(ngx.ERR, "failed broadcasting proxy cache purge to ",
-                    "cluster: ", err)
+            kong.log.err("failed broadcasting proxy cache purge to cluster: ", err)
           end
         end
 
@@ -112,8 +112,7 @@ return {
           then
             local ok, err = broadcast_purge(plugin.id, self.params.cache_key)
             if not ok then
-              ngx.log(ngx.ERR,
-                      "failed broadcasting proxy cache purge to cluster: ", err)
+              kong.log.err("failed broadcasting proxy cache purge to cluster: ", err)
             end
           end
 
@@ -189,8 +188,7 @@ return {
       if require(STRATEGY_PATH).LOCAL_DATA_STRATEGIES[conf.strategy] then
         local ok, err = broadcast_purge(plugin.id, self.params.cache_key)
         if not ok then
-          ngx.log(ngx.ERR, "failed broadcasting proxy cache purge to cluster: ",
-                  err)
+          kong.log.err("failed broadcasting proxy cache purge to cluster: ", err)
         end
       end
 

--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -1,7 +1,14 @@
 local fmt = string.format
 local md5 = ngx.md5
+local type = type
+local pairs = pairs
+local sort = table.sort
+local insert = table.insert
+local concat = table.concat
+
 
 local _M = {}
+
 
 local EMPTY = {}
 
@@ -28,16 +35,16 @@ local function generate_key_from(args, vary_fields)
     local arg = args[field]
     if arg then
       if type(arg) == "table" then
-        table.sort(arg)
-        table.insert(cache_key, field .. "=" .. table.concat(arg, ","))
+        sort(arg)
+        insert(cache_key, field .. "=" .. concat(arg, ","))
 
       else
-        table.insert(cache_key, field .. "=" .. arg)
+        insert(cache_key, field .. "=" .. arg)
       end
     end
   end
 
-  return table.concat(cache_key, ":")
+  return concat(cache_key, ":")
 end
 
 
@@ -48,7 +55,7 @@ end
 local function params_key(params, plugin_config)
   if not (plugin_config.vary_query_params or EMPTY)[1] then
     local actual_keys = keys(params)
-    table.sort(actual_keys)
+    sort(actual_keys)
     return generate_key_from(params, actual_keys)
   end
 

--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -71,21 +71,11 @@ end
 _M.headers_key = headers_key
 
 
-local function prefix_uuid(consumer_id, api_id, route_id)
-
-  -- authenticated api
-  if consumer_id and api_id then
-    return fmt("%s:%s", consumer_id, api_id)
-  end
+local function prefix_uuid(consumer_id, route_id)
 
   -- authenticated route
   if consumer_id and route_id then
     return fmt("%s:%s", consumer_id, route_id)
-  end
-
-  -- unauthenticated api
-  if api_id then
-    return api_id
   end
 
   -- unauthenticated route
@@ -99,11 +89,11 @@ end
 _M.prefix_uuid = prefix_uuid
 
 
-function _M.build_cache_key(consumer_id, api_id, route_id, method, uri,
+function _M.build_cache_key(consumer_id, route_id, method, uri,
                             params_table, headers_table, conf)
 
   -- obtain cache key components
-  local prefix_digest  = prefix_uuid(consumer_id, api_id, route_id)
+  local prefix_digest  = prefix_uuid(consumer_id, route_id)
   local params_digest  = params_key(params_table, conf)
   local headers_digest = headers_key(headers_table, conf)
 

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -249,7 +249,7 @@ end
 
 
 local ProxyCacheHandler = {
-  VERSION  = "1.2.3",
+  VERSION  = "1.3.0",
   PRIORITY = 100,
 }
 
@@ -308,10 +308,9 @@ function ProxyCacheHandler:access(conf)
 
   local ctx = ngx.ctx
   local consumer_id = ctx.authenticated_consumer and ctx.authenticated_consumer.id
-  local api_id = ctx.api and ctx.api.id
   local route_id = ctx.route and ctx.route.id
 
-  local cache_key = cache_key.build_cache_key(consumer_id, api_id, route_id,
+  local cache_key = cache_key.build_cache_key(consumer_id, route_id,
     get_method(),
     ngx_re_sub(ngx.var.request, "\\?.*", "", "oj"),
     ngx_get_uri_args(),
@@ -394,8 +393,8 @@ end
 
 function ProxyCacheHandler:header_filter(conf)
   local ctx = ngx.ctx.proxy_cache
-  -- dont look at our headers if
-  -- a). the request wasnt cachable or
+  -- don't look at our headers if
+  -- a). the request wasn't cachable or
   -- b). the request was served from cache
   if not ctx then
     return

--- a/kong/plugins/proxy-cache/handler.lua
+++ b/kong/plugins/proxy-cache/handler.lua
@@ -1,22 +1,24 @@
+local require     = require
 local cache_key   = require "kong.plugins.proxy-cache.cache_key"
 local utils       = require "kong.tools.utils"
 
 
+local ngx              = ngx
 local kong             = kong
+local type             = type
+local pairs            = pairs
+local tostring         = tostring
+local tonumber         = tonumber
 local max              = math.max
 local floor            = math.floor
-local get_method       = ngx.req.get_method
-local ngx_get_uri_args = ngx.req.get_uri_args
-local ngx_get_headers  = ngx.req.get_headers
+local lower            = string.lower
+local concat           = table.concat
+local time             = ngx.time
 local resp_get_headers = ngx.resp and ngx.resp.get_headers
-local ngx_log          = ngx.log
-local ngx_now          = ngx.now
 local ngx_re_gmatch    = ngx.re.gmatch
 local ngx_re_sub       = ngx.re.gsub
 local ngx_re_match     = ngx.re.match
 local parse_http_time  = ngx.parse_http_time
-local str_lower        = string.lower
-local time             = ngx.time
 
 
 local tab_new = require("table.new")
@@ -24,11 +26,7 @@ local tab_new = require("table.new")
 
 local STRATEGY_PATH = "kong.plugins.proxy-cache.strategies"
 local CACHE_VERSION = 1
-
-
-local function get_now()
-  return ngx_now() * 1000 -- time is kept in seconds with millisecond resolution.
-end
+local EMPTY = {}
 
 
 -- http://www.w3.org/Protocols/rfc2616/rfc2616-sec13.html#sec13.5.1
@@ -48,20 +46,20 @@ local hop_by_hop_headers = {
 
 
 local function overwritable_header(header)
-  local n_header = str_lower(header)
+  local n_header = lower(header)
 
-  return     not hop_by_hop_headers[n_header]
-         and not (ngx_re_match(n_header, "ratelimit-remaining"))
+  return not hop_by_hop_headers[n_header]
+     and not ngx_re_match(n_header, "ratelimit-remaining")
 end
 
 
 local function parse_directive_header(h)
   if not h then
-    return {}
+    return EMPTY
   end
 
   if type(h) == "table" then
-    h = table.concat(h, ", ")
+    h = concat(h, ", ")
   end
 
   local t    = {}
@@ -73,13 +71,13 @@ local function parse_directive_header(h)
     local _, err = ngx_re_match(m[0], [[^\s*([^=]+)(?:=(.+))?]],
                                 "oj", nil, res)
     if err then
-      ngx_log(ngx.ERR, "[proxy-cache] ", err)
+      kong.log.err(err)
     end
 
     -- store the directive token as a numeric value if it looks like a number;
     -- otherwise, store the string value. for directives without token, we just
     -- set the key to true
-    t[str_lower(res[1])] = tonumber(res[2]) or res[2] or true
+    t[lower(res[1])] = tonumber(res[2]) or res[2] or true
 
     m = iter()
   end
@@ -119,11 +117,10 @@ local function resource_ttl(res_cc)
 end
 
 
-local function cacheable_request(ngx, conf, cc)
+local function cacheable_request(conf, cc)
   -- TODO refactor these searches to O(1)
   do
-    local method = get_method()
-
+    local method = kong.request.get_method()
     local method_match = false
     for i = 1, #conf.request_method do
       if conf.request_method[i] == method then
@@ -148,11 +145,10 @@ local function cacheable_request(ngx, conf, cc)
 end
 
 
-local function cacheable_response(ngx, conf, cc)
+local function cacheable_response(conf, cc)
   -- TODO refactor these searches to O(1)
   do
-    local status = ngx.status
-
+    local status = kong.response.get_status()
     local status_match = false
     for i = 1, #conf.response_code do
       if conf.response_code[i] == status then
@@ -203,48 +199,12 @@ end
 
 
 -- indicate that we should attempt to cache the response to this request
-local function signal_cache_req(cache_key, cache_status)
-  ngx.ctx.proxy_cache = {
+local function signal_cache_req(ctx, cache_key, cache_status)
+  ctx.proxy_cache = {
     cache_key = cache_key,
   }
 
-  ngx.header["X-Cache-Status"] = cache_status or "Miss"
-end
-
-
--- define our own response sender instead of using kong.tools.responses
--- as the included response generator always send JSON content
-local function send_response(res)
-  -- simulate the access.after handler
-  --===========================================================
-  local now = get_now()
-
-  ngx.ctx.KONG_ACCESS_TIME = now - ngx.ctx.KONG_ACCESS_START
-  ngx.ctx.KONG_ACCESS_ENDED_AT = now
-
-  local proxy_latency = now - ngx.req.start_time() * 1000
-
-  ngx.ctx.KONG_PROXY_LATENCY = proxy_latency
-
-  ngx.ctx.KONG_PROXIED = true
-  --===========================================================
-
-  ngx.status = res.status
-
-  -- TODO refactor this to not use pairs
-  for k, v in pairs(res.headers) do
-    if overwritable_header(k) then
-      ngx.header[k] = v
-    end
-  end
-
-  ngx.header["Age"] = floor(time() - res.timestamp)
-  ngx.header["X-Cache-Status"] = "Hit"
-
-  ngx.ctx.delayed_response = true
-  ngx.ctx.delayed_response_callback = function()
-    ngx.say(res.body)
-  end
+  kong.response.set_header("X-Cache-Status", cache_status or "Miss")
 end
 
 
@@ -256,21 +216,20 @@ local ProxyCacheHandler = {
 
 function ProxyCacheHandler:init_worker()
   -- catch notifications from other nodes that we purged a cache entry
-  local cluster_events = kong.cluster_events
-
   -- only need one worker to handle purges like this
   -- if/when we introduce inline LRU caching this needs to involve
   -- worker events as well
-  cluster_events:subscribe("proxy-cache:purge", function(data)
-    ngx.log(ngx.ERR, "[proxy-cache] handling purge of '", data, "'")
+  local unpack = unpack
+
+  kong.cluster_events:subscribe("proxy-cache:purge", function(data)
+    kong.log.err("handling purge of '", data, "'")
 
     local plugin_id, cache_key = unpack(utils.split(data, ":"))
-
     local plugin, err = kong.db.plugins:select({
       id = plugin_id,
     })
     if err then
-      ngx_log(ngx.ERR, "[proxy-cache] error in retrieving plugins: ", err)
+      kong.log.err("error in retrieving plugins: ", err)
       return
     end
 
@@ -282,15 +241,14 @@ function ProxyCacheHandler:init_worker()
     if cache_key ~= "nil" then
       local ok, err = strategy:purge(cache_key)
       if not ok then
-        ngx_log(ngx.ERR, "[proxy-cache] failed to purge cache key '", cache_key,
-              "': ", err)
+        kong.log.err("failed to purge cache key '", cache_key, "': ", err)
         return
       end
 
     else
       local ok, err = strategy:flush(true)
       if not ok then
-        ngx_log(ngx.ERR, "[proxy-cache] error in flushing cache data: ", err)
+        kong.log.err("error in flushing cache data: ", err)
       end
     end
   end)
@@ -301,23 +259,23 @@ function ProxyCacheHandler:access(conf)
   local cc = req_cc()
 
   -- if we know this request isnt cacheable, bail out
-  if not cacheable_request(ngx, conf, cc) then
-    ngx.header["X-Cache-Status"] = "Bypass"
+  if not cacheable_request(conf, cc) then
+    kong.response.set_header("X-Cache-Status", "Bypass")
     return
   end
 
-  local ctx = ngx.ctx
-  local consumer_id = ctx.authenticated_consumer and ctx.authenticated_consumer.id
-  local route_id = ctx.route and ctx.route.id
+  local consumer = kong.client.get_consumer()
+  local route = kong.router.get_route()
+  local uri = ngx_re_sub(ngx.var.request, "\\?.*", "", "oj")
+  local cache_key = cache_key.build_cache_key(consumer and consumer.id,
+                                              route    and route.id,
+                                              kong.request.get_method(),
+                                              uri,
+                                              kong.request.get_query(),
+                                              kong.request.get_headers(),
+                                              conf)
 
-  local cache_key = cache_key.build_cache_key(consumer_id, route_id,
-    get_method(),
-    ngx_re_sub(ngx.var.request, "\\?.*", "", "oj"),
-    ngx_get_uri_args(),
-    ngx_get_headers(100),
-    conf)
-
-  ngx.header["X-Cache-Key"] = cache_key
+  kong.response.set_header("X-Cache-Key", cache_key)
 
   -- try to fetch the cached object from the computed cache key
   local strategy = require(STRATEGY_PATH)({
@@ -325,6 +283,7 @@ function ProxyCacheHandler:access(conf)
     strategy_opts = conf[conf.strategy],
   })
 
+  local ctx = kong.ctx.plugin
   local res, err = strategy:fetch(cache_key)
   if err == "request object not in cache" then -- TODO make this a utils enum err
 
@@ -334,51 +293,50 @@ function ProxyCacheHandler:access(conf)
       return kong.response.exit(ngx.HTTP_GATEWAY_TIMEOUT)
     end
 
-    ngx.req.read_body()
-    ngx.ctx.req_body = ngx.req.get_body_data()
+    ctx.req_body = kong.request.get_raw_body()
 
     -- this request is cacheable but wasn't found in the data store
     -- make a note that we should store it in cache later,
     -- and pass the request upstream
-    return signal_cache_req(cache_key)
+    return signal_cache_req(ctx, cache_key)
 
   elseif err then
-    ngx_log(ngx.ERR, "[proxy_cache] ", err)
+    kong.log.err(err)
     return
   end
 
   if res.version ~= CACHE_VERSION then
-    ngx_log(ngx.NOTICE, "[proxy-cache] cache format mismatch, purging ",
-            cache_key)
+    kong.log.notice("cache format mismatch, purging ", cache_key)
     strategy:purge(cache_key)
-    return signal_cache_req(cache_key, "Bypass")
+    return signal_cache_req(ctx, cache_key, "Bypass")
   end
 
   -- figure out if the client will accept our cache value
   if conf.cache_control then
     if cc["max-age"] and time() - res.timestamp > cc["max-age"] then
-      return signal_cache_req(cache_key, "Refresh")
+      return signal_cache_req(ctx, cache_key, "Refresh")
     end
 
     if cc["max-stale"] and time() - res.timestamp - res.ttl > cc["max-stale"]
     then
-      return signal_cache_req(cache_key, "Refresh")
+      return signal_cache_req(ctx, cache_key, "Refresh")
     end
 
     if cc["min-fresh"] and res.ttl - (time() - res.timestamp) < cc["min-fresh"]
     then
-      return signal_cache_req(cache_key, "Refresh")
+      return signal_cache_req(ctx, cache_key, "Refresh")
     end
 
   else
     -- don't serve stale data; res may be stored for up to `conf.storage_ttl` secs
     if time() - res.timestamp > conf.cache_ttl then
-      return signal_cache_req(cache_key, "Refresh")
+      return signal_cache_req(ctx, cache_key, "Refresh")
     end
   end
 
+  -- we have cache data yo!
   -- expose response data for logging plugins
-  ngx.ctx.proxy_cache_hit = {
+  local response_data = {
     res = res,
     req = {
       body = res.req_body,
@@ -386,31 +344,45 @@ function ProxyCacheHandler:access(conf)
     server_addr = ngx.var.server_addr,
   }
 
-  -- we have cache data yo!
-  return send_response(res)
+  kong.ctx.shared.proxy_cache_hit = response_data
+
+  local nctx = ngx.ctx
+  nctx.proxy_cache_hit = response_data -- TODO: deprecated
+  nctx.KONG_PROXIED = true
+
+  for k in pairs(res.headers) do
+    if not overwritable_header(k) then
+      res.headers[k] = nil
+    end
+  end
+
+  res.headers["Age"] = floor(time() - res.timestamp)
+  res.headers["X-Cache-Status"] = "Hit"
+
+  return kong.response.exit(res.status, res.body, res.headers)
 end
 
 
 function ProxyCacheHandler:header_filter(conf)
-  local ctx = ngx.ctx.proxy_cache
+  local ctx = kong.ctx.plugin
+  local proxy_cache = ctx.proxy_cache
   -- don't look at our headers if
-  -- a). the request wasn't cachable or
-  -- b). the request was served from cache
-  if not ctx then
+  -- a) the request wasn't cacheable, or
+  -- b) the request was served from cache
+  if not proxy_cache then
     return
   end
 
   local cc = res_cc()
 
   -- if this is a cacheable request, gather the headers and mark it so
-  if cacheable_response(ngx, conf, cc) then
-    ctx.res_headers = resp_get_headers(0, true)
-    ctx.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
-    ngx.ctx.proxy_cache = ctx
+  if cacheable_response(conf, cc) then
+    proxy_cache.res_headers = resp_get_headers(0, true)
+    proxy_cache.res_ttl = conf.cache_control and resource_ttl(cc) or conf.cache_ttl
 
   else
-    ngx.header["X-Cache-Status"] = "Bypass"
-    ngx.ctx.proxy_cache = nil
+    kong.response.set_header("X-Cache-Status", "Bypass")
+    ctx.proxy_cache = nil
   end
 
   -- TODO handle Vary header
@@ -418,15 +390,16 @@ end
 
 
 function ProxyCacheHandler:body_filter(conf)
-  local ctx = ngx.ctx.proxy_cache
-  if not ctx then
+  local ctx = kong.ctx.plugin
+  local proxy_cache = ctx.proxy_cache
+  if not proxy_cache then
     return
   end
 
   local chunk = ngx.arg[1]
   local eof   = ngx.arg[2]
 
-  ctx.res_body = (ctx.res_body or "") .. (chunk or "")
+  proxy_cache.res_body = (proxy_cache.res_body or "") .. (chunk or "")
 
   if eof then
     local strategy = require(STRATEGY_PATH)({
@@ -435,26 +408,23 @@ function ProxyCacheHandler:body_filter(conf)
     })
 
     local res = {
-      status    = ngx.status,
-      headers   = ctx.res_headers,
-      body      = ctx.res_body,
-      body_len  = #ctx.res_body,
+      status    = kong.response.get_status(),
+      headers   = proxy_cache.res_headers,
+      body      = proxy_cache.res_body,
+      body_len  = #proxy_cache.res_body,
       timestamp = time(),
-      ttl       = ctx.res_ttl,
+      ttl       = proxy_cache.res_ttl,
       version   = CACHE_VERSION,
-      req_body  = ngx.ctx.req_body,
+      req_body  = ctx.req_body,
     }
 
-    local ttl = conf.storage_ttl or conf.cache_control and ctx.res_ttl or
+    local ttl = conf.storage_ttl or conf.cache_control and proxy_cache.res_ttl or
                 conf.cache_ttl
 
-    local ok, err = strategy:store(ctx.cache_key, res, ttl)
+    local ok, err = strategy:store(proxy_cache.cache_key, res, ttl)
     if not ok then
-      ngx_log(ngx.ERR, "[proxy-cache] ", err)
+      kong.log(err)
     end
-
-  else
-    ngx.ctx.proxy_cache = ctx
   end
 end
 

--- a/kong/plugins/proxy-cache/schema.lua
+++ b/kong/plugins/proxy-cache/schema.lua
@@ -1,5 +1,9 @@
 local strategies = require "kong.plugins.proxy-cache.strategies"
 
+
+local ngx = ngx
+
+
 local function check_shdict(name)
   if not ngx.shared[name] then
     return false, "missing shared dict '" .. name .. "'"
@@ -7,6 +11,7 @@ local function check_shdict(name)
 
   return true
 end
+
 
 return {
   name = "proxy-cache",

--- a/kong/plugins/proxy-cache/strategies/init.lua
+++ b/kong/plugins/proxy-cache/strategies/init.lua
@@ -1,3 +1,7 @@
+local require = require
+local setmetatable = setmetatable
+
+
 local _M = {}
 
 _M.STRATEGY_TYPES = {

--- a/kong/plugins/proxy-cache/strategies/memory.lua
+++ b/kong/plugins/proxy-cache/strategies/memory.lua
@@ -5,8 +5,7 @@ local ngx          = ngx
 local type         = type
 local time         = ngx.time
 local shared       = ngx.shared
-local cjson_encode = cjson.encode
-local cjson_decode = cjson.decode
+local setmetatable = setmetatable
 
 
 local _M = {}
@@ -42,7 +41,7 @@ function _M:store(key, req_obj, req_ttl)
   end
 
   -- encode request table representation as JSON
-  local req_json = cjson_encode(req_obj)
+  local req_json = cjson.encode(req_obj)
   if not req_json then
     return nil, "could not encode request object"
   end
@@ -72,7 +71,7 @@ function _M:fetch(key)
   end
 
   -- decode object from JSON to table
-  local req_obj = cjson_decode(req_json)
+  local req_obj = cjson.decode(req_json)
   if not req_json then
     return nil, "could not decode request object"
   end
@@ -111,7 +110,7 @@ function _M:touch(key, req_ttl, timestamp)
   end
 
   -- decode object from JSON to table
-  local req_obj = cjson_decode(req_json)
+  local req_obj = cjson.decode(req_json)
   if not req_json then
     return nil, "could not decode request object"
   end

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -463,7 +463,7 @@ do
 
       assert.res_status(200, res)
       assert.same("Miss", res.headers["X-Cache-Status"])
-      local cache_key = res.headers["X-Cache-Key"]
+      --local cache_key = res.headers["X-Cache-Key"]
 
       -- wait until the underlying strategy converges
       --strategy_wait_until(policy, function()

--- a/spec/05-cache_key_spec.lua
+++ b/spec/05-cache_key_spec.lua
@@ -7,36 +7,10 @@ describe("prefix_uuid", function()
   local consumer2_uuid = utils.uuid()
   local route1_uuid = utils.uuid()
   local route2_uuid = utils.uuid()
-  local api1_uuid = utils.uuid()
-  local api2_uuid = utils.uuid()
-
-  it("returns distinct prefixes for a consumer on different apis", function()
-    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, api1_uuid,
-      nil))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, api2_uuid,
-      nil))
-
-    assert.not_equal(prefix1, prefix2)
-    assert.not_equal("default", prefix1)
-    assert.not_equal("default", prefix2)
-  end)
-
-  it("returns distinct prefixes for different consumers on an api", function()
-    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, api1_uuid,
-                           route1_uuid))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer2_uuid, api1_uuid,
-                           route2_uuid))
-
-    assert.not_equal(prefix1, prefix2)
-    assert.not_equal("default", prefix1)
-    assert.not_equal("default", prefix2)
-  end)
 
   it("returns distinct prefixes for a consumer on different routes", function()
-    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, nil,
-      route1_uuid))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, nil,
-      route2_uuid))
+    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, route1_uuid))
+    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, route2_uuid))
 
     assert.not_equal(prefix1, prefix2)
     assert.not_equal("default", prefix1)
@@ -44,61 +18,41 @@ describe("prefix_uuid", function()
   end)
 
   it("returns distinct prefixes for different consumers on a route", function()
-    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, nil,
-      route1_uuid))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer2_uuid, nil,
-      route1_uuid))
+    local prefix1 = assert(key_utils.prefix_uuid(consumer1_uuid, route1_uuid))
+    local prefix2 = assert(key_utils.prefix_uuid(consumer2_uuid, route1_uuid))
 
     assert.not_equal(prefix1, prefix2)
     assert.not_equal("default", prefix1)
     assert.not_equal("default", prefix2)
   end)
 
-  it("returns the same prefix for an api with no consumer", function()
-    local prefix1 = assert(key_utils.prefix_uuid(nil, api1_uuid, nil))
-    local prefix2 = assert(key_utils.prefix_uuid(nil, api1_uuid, nil))
-
-    assert.equal(prefix1, prefix2)
-    assert.not_equal("default", prefix1)
-  end)
-
   it("returns the same prefix for a route with no consumer", function()
-    local prefix1 = assert(key_utils.prefix_uuid(nil, nil, route1_uuid))
-    local prefix2 = assert(key_utils.prefix_uuid(nil, nil, route1_uuid))
+    local prefix1 = assert(key_utils.prefix_uuid(nil, route1_uuid))
+    local prefix2 = assert(key_utils.prefix_uuid(nil, route1_uuid))
 
     assert.equal(prefix1, prefix2)
     assert.not_equal("default", prefix1)
-  end)
-
-  it("returns a consumer-specific prefix for apis", function()
-    local prefix1 = assert(key_utils.prefix_uuid(nil, api1_uuid, nil))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, api1_uuid, nil))
-
-    assert.not_equal(prefix1, prefix2)
   end)
 
   it("returns a consumer-specific prefix for routes", function()
-    local prefix1 = assert(key_utils.prefix_uuid(nil, nil, route1_uuid))
-    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, nil, route1_uuid))
+    local prefix1 = assert(key_utils.prefix_uuid(nil, route1_uuid))
+    local prefix2 = assert(key_utils.prefix_uuid(consumer1_uuid, route1_uuid))
 
     assert.not_equal(prefix1, prefix2)
   end)
 
   describe("returns 'default' if", function()
     it("no consumer_id, api_id, or route_id was given", function()
-      assert.equal("default", key_utils.prefix_uuid(nil, nil, nil))
+      assert.equal("default", key_utils.prefix_uuid())
     end)
     it("only consumer_id was given", function()
-      assert.equal("default", key_utils.prefix_uuid(consumer1_uuid, nil, nil))
+      assert.equal("default", key_utils.prefix_uuid(consumer1_uuid))
     end)
   end)
 
   describe("does not return 'default' if", function()
-    it("api_id is non-nil", function()
-      assert.not_equal("default", key_utils.prefix_uuid(nil, api1_uuid, nil))
-    end)
     it("route_id is non-nil", function()
-      assert.not_equal("default", key_utils.prefix_uuid(nil, route1_uuid, nil))
+      assert.not_equal("default", key_utils.prefix_uuid(nil, route1_uuid))
     end)
   end)
 end)


### PR DESCRIPTION
 ### Summary
    
APIs where removed from Kong `1.0` and were replaced with `routes` and `services.` So dropping it from here too.

This also refactors the code to use `pdk`, and localizes some function access.

### Issues Resolved

Also fixes #17 and closes #18