### PR TITLE
Fix error 500 on null URL arg

### DIFF
--- a/kong/plugins/proxy-cache/cache_key.lua
+++ b/kong/plugins/proxy-cache/cache_key.lua
@@ -1,4 +1,5 @@
 local fmt = string.format
+local ipairs = ipairs
 local md5 = ngx.md5
 local type = type
 local pairs = pairs
@@ -31,15 +32,18 @@ end
 local function generate_key_from(args, vary_fields)
   local cache_key = {}
 
-  for _, field in pairs(vary_fields or {}) do
+  for _, field in ipairs(vary_fields or {}) do
     local arg = args[field]
     if arg then
       if type(arg) == "table" then
         sort(arg)
         insert(cache_key, field .. "=" .. concat(arg, ","))
 
+      elseif arg == true then
+        insert(cache_key, field)
+
       else
-        insert(cache_key, field .. "=" .. arg)
+        insert(cache_key, field .. "=" .. tostring(arg))
       end
     end
   end

--- a/spec/02-access_spec.lua
+++ b/spec/02-access_spec.lua
@@ -908,6 +908,26 @@ do
 
       assert.res_status(200, res)
       assert.same("Hit", res.headers["X-Cache-Status"])
+
+      res = assert(client:send {
+        method = "GET",
+        path = "/get?a&b",
+        headers = {
+          host = "route-1.com",
+        }
+      })
+      assert.res_status(200, res)
+      assert.same("Miss", res.headers["X-Cache-Status"])
+
+      res = assert(client:send {
+        method = "GET",
+        path = "/get?a&b",
+        headers = {
+          host = "route-1.com",
+        }
+      })
+      assert.res_status(200, res)
+      assert.same("Hit", res.headers["X-Cache-Status"])
     end)
 
     it("can focus only in a subset of the query arguments", function()


### PR DESCRIPTION
A null URL argument (like `?arg&..`, without `=`) is parsed as a boolean
 `true` value.  When building the cache key it can't be blindly
 concatenated.

 Fix: #27

 Note, the reported issue is actually about the Enterprise "advanced"
 proxy cache, which presents the same bug.